### PR TITLE
Update ComputerCore.cs

### DIFF
--- a/FNPlugin/ComputerCore.cs
+++ b/FNPlugin/ComputerCore.cs
@@ -166,7 +166,7 @@ namespace FNPlugin {
 		}
 
 		public static string getNameFilePath() {
-			return KSPUtil.ApplicationRootPath + "gamedata/warpplugin/NameList.cfg";
+			return KSPUtil.ApplicationRootPath + "GameData/WarpPlugin/NameList.cfg";
 		}
 
 		public static ConfigNode[] getNames() {


### PR DESCRIPTION
FIX: ComputerCore - Retrofit, did not work on Linux because of the path being lowercase.
