### PR TITLE
Move PluginHelper.getPluginSaveFile() outside loop

### DIFF
--- a/FNPlugin/MicrowavePowerReceiver.cs
+++ b/FNPlugin/MicrowavePowerReceiver.cs
@@ -127,11 +127,11 @@ namespace FNPlugin {
             }
             vmps = new List<VesselMicrowavePersistence>();
             vrps = new List<VesselRelayPersistence>();
+            ConfigNode config = PluginHelper.getPluginSaveFile();
             foreach (Vessel vess in FlightGlobals.Vessels) {
                 String vesselID = vess.id.ToString();
 
                 if (vess.isActiveVessel == false && vess.vesselName.ToLower().IndexOf("debris") == -1) {
-                    ConfigNode config = PluginHelper.getPluginSaveFile();
                     if (config.HasNode("VESSEL_MICROWAVE_POWER_" + vesselID)) {
                         ConfigNode power_node = config.GetNode("VESSEL_MICROWAVE_POWER_" + vesselID);
                         double nuclear_power = 0;


### PR DESCRIPTION
I'm noticing a significant performance degradation as my career-mode game progresses. This may not be related, but at the very least we don't need to parse the config file once per vessel per microwave receiver.
