### PR TITLE
B9 changes

### DIFF
--- a/GameData/WarpPlugin/b9aero.cfg
+++ b/GameData/WarpPlugin/b9aero.cfg
@@ -37,7 +37,7 @@
         name = FNRadiator
         isDeployable = false
         radiatorTemp = 1350
-        radiatorArea = 80
+        radiatorArea = 40
         originalName = Mo Li Heat Pipe
         upgradeCost = 5
         upgradedName = Graphene Radiator
@@ -53,7 +53,7 @@
         name = FNRadiator
         isDeployable = false
         radiatorTemp = 1350
-        radiatorArea = 6.5
+        radiatorArea = 6.6
         originalName = Mo Li Heat Pipe
         upgradeCost = 5
         upgradedName = Graphene Radiator
@@ -101,7 +101,7 @@
         name = FNRadiator
         isDeployable = false
         radiatorTemp = 1350
-        radiatorArea = 6.5
+        radiatorArea = 6.6
         originalName = Mo Li Heat Pipe
         upgradeCost = 5
         upgradedName = Graphene Radiator
@@ -117,7 +117,7 @@
         name = FNRadiator
         isDeployable = false
         radiatorTemp = 1350
-        radiatorArea = 19.5
+        radiatorArea = 19.8
         originalName = Mo Li Heat Pipe
         upgradeCost = 5
         upgradedName = Graphene Radiator
@@ -149,7 +149,7 @@
         name = FNRadiator
         isDeployable = false
         radiatorTemp = 1350
-        radiatorArea = 60
+        radiatorArea = 30
         originalName = Mo Li Heat Pipe
         upgradeCost = 5
         upgradedName = Graphene Radiator

--- a/GameData/WarpPlugin/b9aero.cfg
+++ b/GameData/WarpPlugin/b9aero.cfg
@@ -1,79 +1,191 @@
 @PART[B9_Aero_HL_Body_Cargo_A]
 {
-MODULE
-{
-	name = FNRadiator
-	isDeployable = false
-	radiatorTemp = 1350
-	radiatorArea = 10
-	originalName = Mo Li Heat Pipe
-	upgradeCost = 5
-	upgradedName = Graphene Radiator
-	upgradedRadiatorTemp = 3500
-	upgradeTechReq = experimentalElectrics
-}
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 10
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
 }
 
 @PART[B9_Aero_HL_Body_Cargo_B]
 {
-MODULE
-{
-	name = FNRadiator
-	isDeployable = false
-	radiatorTemp = 1350
-	radiatorArea = 30
-	originalName = Mo Li Heat Pipe
-	upgradeCost = 5
-	upgradedName = Graphene Radiator
-	upgradedRadiatorTemp = 3500
-	upgradeTechReq = experimentalElectrics
-}
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 20
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
 }
 
 @PART[B9_Aero_HL_Body_Cargo_C]
 {
-MODULE
-{
-	name = FNRadiator
-	isDeployable = false
-	radiatorTemp = 1350
-	radiatorArea = 90
-	originalName = Mo Li Heat Pipe
-	upgradeCost = 5
-	upgradedName = Graphene Radiator
-	upgradedRadiatorTemp = 3500
-	upgradeTechReq = experimentalElectrics
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 80
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
 }
+
+@PART[B9_Cargo_M2_Body_B]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 6.5
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_MK2_Body_Cargo_2m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 4
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_MK2_Body_Cargo_5m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 10
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_S2_Body_Cargo_2m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 6.5
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_S2_Body_Cargo_6m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 19.5
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_S2_BodyLarge_Cargo_2m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 10
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
+}
+
+@PART[B9_Cockpit_S2_BodyLarge_Cargo_6m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 60
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+    }
 }
 
 @PART[B9_Engine_SABRE_S]
 {
-MODULE
-{
-	name = ModuleSabreHeating
-}		
+    MODULE
+    {
+        name = ModuleSabreHeating
+    }
 }
 
 @PART[B9_Engine_SABRE_M]
 {
-MODULE
-{
-	name = ModuleSabreHeating
-}		
+    MODULE
+    {
+        name = ModuleSabreHeating
+    }
 }
 
 @PART[B9_Engine_SABRE_S_Body]
 {
-MODULE
-{
-	name = FNModulePreecooler
-}
+    MODULE
+    {
+        name = FNModulePreecooler
+    }
 }
 
 @PART[B9_Engine_SABRE_M_Body]
 {
-MODULE
-{
-	name = FNModulePreecooler
-}
+    MODULE
+    {
+        name = FNModulePreecooler
+    }
 }


### PR DESCRIPTION
I don't really get to play KSP much, but lots of our users also use KSPi, so here is the patch I sent in for WaveFunctionP's branch.

Fixes a faulty scaling in the HL radiator sizes (the fuselage lengths are 2m, 4m and 8m) and adds radiators to the other cargo bays. I think I scaled them right (by surface area).
