### PR TITLE
Fix tritium not breeding in background

### DIFF
--- a/FNPlugin/InterstellarReactor.cs
+++ b/FNPlugin/InterstellarReactor.cs
@@ -307,6 +307,7 @@ namespace FNPlugin {
                     IsEnabled = false;
                     return;
                 }
+
                 // Max Power
                 double max_power_to_supply = Math.Max(MaximumPower * TimeWarp.fixedDeltaTime, 0);
                 double fuel_ratio = Math.Min(current_fuel_mode.ReactorFuels.Min(fuel => getFuelAvailability(fuel) / fuel.GetFuelUseForPower(FuelEfficiency,max_power_to_supply)), 1.0);
@@ -328,6 +329,7 @@ namespace FNPlugin {
                 double total_power_received = thermal_power_received + charged_power_received;
                 total_power_per_frame = total_power_received;
                 double total_power_ratio = total_power_received / MaximumPower / TimeWarp.fixedDeltaTime;
+                ongoing_consumption_rate = (float)total_power_ratio;
 
                 foreach (ReactorFuel fuel in current_fuel_mode.ReactorFuels) consumeReactorFuel(fuel, total_power_received * fuel.FuelUsePerMJ); // consume fuel
                  
@@ -338,7 +340,6 @@ namespace FNPlugin {
                 powerPcnt = 100.0 * total_power_ratio;
 
                 if (min_throttle > 1.05) IsEnabled = false;
-
                 if (breedtritium) 
                 {
                     PartResourceDefinition lithium_def = PartResourceLibrary.Instance.GetDefinition(InterstellarResourcesConfiguration.Instance.Lithium);
@@ -351,6 +352,11 @@ namespace FNPlugin {
                     if (tritium_produced_f <= 0) breedtritium = false;
                 }
 
+                if(Planetarium.GetUniversalTime() != 0)
+                {
+                    last_active_time = (float)(Planetarium.GetUniversalTime());
+                }
+
             } else if (MaximumPower > 0 && Planetarium.GetUniversalTime() - last_active_time <= 3 * 86400 && IsNuclear)
             {
                 double daughter_half_life = 86400.0 / 24.0 * 9.0;
@@ -359,6 +365,7 @@ namespace FNPlugin {
                 double power_to_supply = Math.Max(MaximumPower * TimeWarp.fixedDeltaTime * power_fraction, 0);
                 double thermal_power_received = supplyManagedFNResourceWithMinimum(power_to_supply, 1.0, FNResourceManager.FNRESOURCE_THERMALPOWER);
                 double total_power_ratio = thermal_power_received / MaximumPower / TimeWarp.fixedDeltaTime;
+                ongoing_consumption_rate = (float)total_power_ratio;
                 supplyFNResource(thermal_power_received, FNResourceManager.FNRESOURCE_WASTEHEAT); // generate heat that must be dissipated
                 powerPcnt = 100.0 * total_power_ratio;
                 decay_ongoing = true;


### PR DESCRIPTION
In Interstellar 0.13, tritium is not breeding for me on unfocused vessels even when the same setup would successfully breed tritium when it was the active vessel.

To reproduce the issue, create a tritium breeder (I used a fission reactor, generator, lithium, tritium cryostat and microwave transmitter to keep the reactor at 100%), enable tritium breeding and timewarp for a while while watching the amount of LqdTritium on the vessel. It should increase. Now, note the amount of tritium on the vessel, switch to the SpaceCenter (or otherwise make the tritium breeder not the active vessel) and timewarp a similar period of time. Switch back to the tritium breeder and compare the LqdTritium levels to the value previously noted. Without this patch, no additional tritium will have been produced in the background.

There were two variables that weren't getting set anymore that caused this problem. I referenced the reactor code from 0.10.3 ( https://github.com/FractalUK/KSPInterstellar/blob/def545fc24007fdbd0390ab667ba78a8f2f19d77/FNPlugin/FNReactor.cs ) for how things should work:
1. last_active_time was not getting set, so the doPersistentResourceUpdate() function never got called and any time deltas wouldn't make sense even if it were.
2. ongoing_consumption_rate was not getting set, so the persistent resource update acted like the reactor was always at 0% power.
