### PR TITLE
Microwave fixes

### DIFF
--- a/FNPlugin/MicrowavePowerReceiver.cs
+++ b/FNPlugin/MicrowavePowerReceiver.cs
@@ -209,7 +209,7 @@ namespace FNPlugin {
                     return;
                 }
 
-                if (++counter % 20 == 1)       // recalculate input once per 20 physics cycles. Relay route algorythm is too expensive
+                if (++counter % 10 == 1)       // recalculate input once per 10 physics cycles. Relay route algorythm is too expensive
                 {
                     double total_power = 0;
                     int activeSatsIncr = 0;

--- a/FNPlugin/MicrowavePowerReceiver.cs
+++ b/FNPlugin/MicrowavePowerReceiver.cs
@@ -252,8 +252,6 @@ namespace FNPlugin {
         uint counter = 0;       // OnFixedUpdate cycle counter
 
         public override void OnFixedUpdate() {
-            int activeSatsIncr = 0;
-            //int activeRelsIncr = 0;
             
             base.OnFixedUpdate();
             if (receiverIsEnabled) {
@@ -266,12 +264,13 @@ namespace FNPlugin {
                     return;
                 }
 
-                if (counter % 1000 == 999)
+                if (counter % 100 == 249)
                     loadTransmitterAndRelayLists();     // reload transmitter lists every 1000 cycles;
 
                 if (++counter % 20 == 1)       // recalculate input once per 20 physics cycles. Relay route algorythm is too expensive
                 {
                     double total_power = 0;
+                    int activeSatsIncr = 0;
                     connectedsatsi = 0;
                     connectedrelaysi = 0;
                     networkDepth = 0;
@@ -319,21 +318,19 @@ namespace FNPlugin {
 
                     powerInputMegajoules = total_power / 1000.0 * GameConstants.microwave_dish_efficiency * atmosphericefficiency * receiptPower / 100.0f;
                     powerInput = powerInputMegajoules * 1000.0f;
+                }
 
+                float animateTemp = (float)powerInputMegajoules / 3000;
+                if (animateTemp > 1)
+                {
+                    animateTemp = 1;
+                }
 
-                    float animateTemp = (float)powerInputMegajoules / 3000;
-                    if (animateTemp > 1)
-                    {
-                        animateTemp = 1;
-                    }
-
-                    if (animT != null)
-                    {
-                        animT[animTName].speed = 0.001f;
-                        animT[animTName].normalizedTime = animateTemp;
-                        animT.Blend(animTName, 2f);
-                    }
-
+                if (animT != null)
+                {
+                    animT[animTName].speed = 0.001f;
+                    animT[animTName].normalizedTime = animateTemp;
+                    animT.Blend(animTName, 2f);
                 }
 
                 if (!isThermalReceiver) {

--- a/FNPlugin/MicrowavePowerReceiver.cs
+++ b/FNPlugin/MicrowavePowerReceiver.cs
@@ -41,7 +41,7 @@ namespace FNPlugin {
         [KSPField(isPersistant = false, guiActive = true, guiName = "Total Efficiency")]
         public string toteff;
         [KSPField(isPersistant = true, guiActive = true, guiName = "Reception"), UI_FloatRange(stepIncrement = 0.005f, maxValue = 100, minValue = 1)]
-        public float receiptPower;
+        public float receiptPower = 100;
 
         //Internal 
 
@@ -82,7 +82,6 @@ namespace FNPlugin {
         [KSPEvent(guiActive = true, guiName = "Activate Receiver", active = true)]
         public void ActivateReceiver() {
             receiverIsEnabled = true;
-            receiptPower = 100;
         }
 
         [KSPEvent(guiActive = true, guiName = "Disable Receiver", active = true)]

--- a/FNPlugin/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/MicrowavePowerTransmitter.cs
@@ -177,6 +177,8 @@ namespace FNPlugin {
             nuclear_power = 0;
             solar_power = 0;
             displayed_solar_power = 0;
+
+            base.OnFixedUpdate();
             if (IsEnabled && !relay) {
                 foreach (FNGenerator generator in generators) {
                     if (generator.isActive()) {

--- a/FNPlugin/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/MicrowavePowerTransmitter.cs
@@ -214,7 +214,7 @@ namespace FNPlugin {
                 solar_power = 0;
             } 
 
-            if (activeCount % 1000 == 9) {
+            if (activeCount % 250 == 9) {
                 ConfigNode config = PluginHelper.getPluginSaveFile();
                 string vesselID = vessel.id.ToString();
                 if (config.HasNode("VESSEL_MICROWAVE_POWER_" + vesselID)) {

--- a/FNPlugin/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/MicrowavePowerTransmitter.cs
@@ -27,7 +27,7 @@ namespace FNPlugin {
         [KSPField(isPersistant = false, guiActive = true, guiName = "Beamed Power")]
         public string beamedpower;
         [KSPField(isPersistant = true, guiActive = true, guiName = "Transmission"), UI_FloatRange(stepIncrement = 0.005f, maxValue = 100, minValue = 1)]
-        public float transmitPower;
+        public float transmitPower = 100;
 
         //Internal
         protected Animation anim;
@@ -46,7 +46,6 @@ namespace FNPlugin {
                 anim[animName].normalizedTime = 0f;
                 anim.Blend(animName, 2f);
             }
-            transmitPower = 100;
             IsEnabled = true;
         }
 

--- a/FNPlugin/MicrowaveSources.cs
+++ b/FNPlugin/MicrowaveSources.cs
@@ -21,12 +21,11 @@ namespace FNPlugin
         void Start()
         {
             instance = this;
-            Debug.Log("[KSP Interstellar]: MicrowaveSources.Start called");
+            Debug.Log("[KSP Interstellar]: MicrowaveSources initialized");
         }
 
         public void calculateTransmitters()
         {
-            Debug.Log("[KSP Interstellar]: MicrowaveSources.calculateTransmitters called");
             transmitters.Clear();
             relays.Clear();
             foreach (var vessel in FlightGlobals.Vessels)
@@ -45,7 +44,6 @@ namespace FNPlugin
                         relays.Add(persistence_relay);
                     }
                 }
-                Debug.Log("[KSP Interstellar]: MicrowaveSources.calculateTransmitters called -" + transmitters.ToString());
             }            
         }
 

--- a/FNPlugin/MicrowaveSources.cs
+++ b/FNPlugin/MicrowaveSources.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace FNPlugin
+{
+    [KSPAddon(KSPAddon.Startup.EveryScene, false)]
+    class MicrowaveSources : MonoBehaviour
+    {
+        public Dictionary<Vessel, VesselMicrowavePersistence> transmitters = new Dictionary<Vessel, VesselMicrowavePersistence>();
+        public List<VesselRelayPersistence> relays = new List<VesselRelayPersistence>();
+
+        public static MicrowaveSources instance
+        {
+            get;
+            private set;
+        }
+
+        void Start()
+        {
+            instance = this;
+            Debug.Log("[KSP Interstellar]: MicrowaveSources.Start called");
+        }
+
+        public void calculateTransmitters()
+        {
+            Debug.Log("[KSP Interstellar]: MicrowaveSources.calculateTransmitters called");
+            transmitters.Clear();
+            relays.Clear();
+            foreach (var vessel in FlightGlobals.Vessels)
+            {
+                var transes = vessel.FindPartModulesImplementing<MicrowavePowerTransmitter>();
+                if (transes.Count > 0)
+                {
+                    var persistence = new VesselMicrowavePersistence(vessel);
+                    persistence.setNuclearPower( MicrowavePowerTransmitter.getEnumeratedNuclearPowerForVessel(vessel));
+                    persistence.setSolarPower(MicrowavePowerTransmitter.getEnumeratedSolarPowerForVessel(vessel));
+                    transmitters[vessel] = persistence;
+                    if (MicrowavePowerTransmitter.vesselIsRelay(vessel))
+                    {
+                        var persistence_relay = new VesselRelayPersistence(vessel);
+                        persistence_relay.setActive(true);
+                        relays.Add(persistence_relay);
+                    }
+                }
+                Debug.Log("[KSP Interstellar]: MicrowaveSources.calculateTransmitters called -" + transmitters.ToString());
+            }            
+        }
+
+        uint counter = 0;
+        void Update()                  // update every 40 frames
+        {
+            if (counter++ % 40 == 0)
+                calculateTransmitters();
+        }
+    }
+}


### PR DESCRIPTION
There was a problem with updating microwave network stats. Recievers didn't know about changing values of transmitters. The list of transmitters was parsed (from WarpPlugin.cfg) by reciever only during startup (no dynamic power changing), wich is bad. There was also a trivial problem of waste heat generated independently of reciever gain amount. There is no need to poke file system so frequently also. Now the lists of microwave emitters and relays are part of the addon, wich updates them once per 40 frames. WarpPlugin.cfg code in Microwave... classes was deleted. Instead, persistent values needed for background power computations are switched to float type and saved using standard KSP PartModule mechanics. Relay optimal way search algorithm call frequency has changed to once per 10 physic steps. It may be decreased, but it's viable only for fast-rotating crafts. Assuming the computational cost of this procedure (MicrowavePowerReceiver.GetConnectedTransmitters), i would recomment evading every physics frame recalculations.

More testing is advised, but i didn't changed much really. Only architectural changes.
